### PR TITLE
Add status code to response

### DIFF
--- a/src/components/response.jsx
+++ b/src/components/response.jsx
@@ -26,10 +26,12 @@ module.exports = React.createClass({
 
   render() {
     let responseHeaders = _.get(this.props.response, 'headers');
+    let responseStatus = _.get(this.props.response, 'statusCode');
     let responseBody = _.get(this.props.response, 'body');
 
     return (
       <div className={(_.isEmpty(this.props.response) ? 'hidden' : '')}>
+        <p className={"status-code " + (responseStatus < 400 ? 'success' : 'error')}>Status: {responseStatus}</p>
         <Tabs>
             <Tab title="Body">
               {

--- a/src/main.css
+++ b/src/main.css
@@ -40,3 +40,17 @@ button.pressed {
 	flex-grow: 1;
 	overflow: auto;
 }
+
+.status-code {
+	margin: 0;
+	padding: 5px;
+	color: #fff;
+}
+
+.status-code.success {
+	background: #00C96B;
+}
+
+.status-code.error {
+	background: #D90000;
+}


### PR DESCRIPTION
It was previously not possible to see the response status code. Added it above the tabs.

Status code < 400 will yield green, anything above will yield red.

![screen shot 2016-05-19 at 09 58 38](https://cloud.githubusercontent.com/assets/486949/15386572/d35fc6ee-1da8-11e6-8757-7f22830861e6.png)
![screen shot 2016-05-19 at 09 58 49](https://cloud.githubusercontent.com/assets/486949/15386571/d35e38b0-1da8-11e6-80e4-9bc180e09da4.png)
