### PR TITLE
Added electron-prebuilt-compile to compile less

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "main": "main.js",
   "scripts": {
-    "start": "electron .",
+    "start": "./node_modules/electron-prebuilt-compile/lib/cli.js .",
     "package": "electron-packager ./ --platform=darwin --arch=x64 --out=./sqren-build --ignore=sqren-build --overwrite"
   },
   "repository": {
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "electron-packager": "^7.0.1",
-    "electron-prebuilt": "^1.0.0"
+    "electron-prebuilt": "^1.0.0",
+    "electron-prebuilt-compile": "^1.1.1"
   }
 }

--- a/src/main.less
+++ b/src/main.less
@@ -3,20 +3,6 @@ html, body, #fbapi-app {
 	margin: 0;
 }
 
-.query-container-toggle-button, .send-button, .body-container-toggle-button {
-	top: 21px;
-	position: relative;
-}
-
-.body-container-toggle-button button {
-	margin-left: 22px;
-}
-
-.request-body-container textarea {
-	max-height: 300px;
-	overflow: scroll;
-}
-
 .hidden {
 	display: none;
 }
@@ -33,7 +19,21 @@ button.pressed {
 
 .request-container {
 	border-bottom: 1px solid #eee;
-	flex-shrink: 0
+	flex-shrink: 0;
+
+	.query-container-toggle-button, .send-button, .body-container-toggle-button {
+		top: 21px;
+		position: relative;
+	}
+
+	.body-container-toggle-button button {
+		margin-left: 22px;
+	}
+
+	.request-body-container textarea {
+		max-height: 300px;
+		overflow: scroll;
+	}
 }
 
 .response-container {
@@ -45,12 +45,13 @@ button.pressed {
 	margin: 0;
 	padding: 5px;
 	color: #fff;
-}
 
-.status-code.success {
-	background: #00C96B;
-}
+	&.success {
+		background: #00C96B;
+	}
 
-.status-code.error {
-	background: #D90000;
+	&.error {
+		background: #D90000;
+	}
+
 }

--- a/src/primaryWindow.html
+++ b/src/primaryWindow.html
@@ -3,8 +3,8 @@
   <head>
     <link href="http://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link type="text/css" rel="stylesheet" href="./3rd-parties/materialize/css/materialize.min.css"/>
-    <link type="text/css" rel="stylesheet" href="./main.css"/>
     <link rel="stylesheet" type="text/css" href="https://rawgit.com/Pixabay/JavaScript-autoComplete/master/auto-complete.css">
+    <link rel="stylesheet" href="./main.less"/>
   </head>
 
   <body>


### PR DESCRIPTION
This will enable less files to be compiled on run-time. Changes to less files will be reflected upon simple page reload (restart of the process not required).

This is achieved with https://github.com/electron/electron-compile

@lieberkind 
